### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -28,12 +28,14 @@ global.sleep = (time: number) => {
 export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    const isChallengeEnabled = utils.isChallengeEnabled(challenges.noSqlCommandChallenge)
+    const id = isChallengeEnabled ? utils.trunc(req.params.id, 40) : Number(req.params.id)
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    // Use a parameterized query to avoid code injection
+    db.reviewsCollection.find({ product: isChallengeEnabled ? id : Number(id) }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/uchoa3211-5-cmd/juice-shopAda1466/security/code-scanning/53](https://github.com/uchoa3211-5-cmd/juice-shopAda1466/security/code-scanning/53)

To fix the code injection, we must ensure that user input (`id`) cannot be interpreted as executable code in the context of the MongoDB `$where` query. The best way is to avoid using `$where` entirely for user-provided values — instead, use direct MongoDB queries with parameterization.

- For non-challenge mode, this is already intended: use `{ product: id }` as the query, where `id` is a number.
- For challenge mode, if some input control is allowed, we should still prevent code injection and avoid `$where` or, if we must use it (e.g., for the challenge), ensure that `id` is sanitized or use parameterized conditions.
- To maintain existing functionality *and* prevent code injection, update the query:
  - For normal use (challenge disabled): `db.reviewsCollection.find({ product: id })`
  - For challenge mode: if the intention is to still demo a vulnerability, perhaps leave in a safe way, but in a real fix, treat the input as a string or number and use `{ product: id }` or at least strictly escape/sanitize it to prevent arbitrary code execution.
- The optimal security fix is: eliminate `$where` and use strictly parameterized queries in both branches.
- Only routes/showProductReviews.ts requires a change; lib/utils.ts is not directly relevant for the injection surface.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
